### PR TITLE
feat: timeouts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
 
 name: 🔍 Quality Control
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,10 @@ edition = "2021"
 [dependencies]
 log = "0.4.19"
 thiserror = "1.0.40"
-tokio = { version = "1.28.2", features = ["rt", "rt-multi-thread", "macros", "net"] }
+tokio = { version = "1.28.2", features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "time",
+  "net",
+] }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Pure Rust async implementation of the [Source RCON protocol](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol).
 
+```rust
+use sourcon::client::Client;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let host = "dev.viora.sh:27015";
+
+    // client must be mutable
+    let mut client = Client::connect(host, "poop").await?;
+
+    let response = client.command("echo hi").await?;
+    assert_eq!(response.body(), "hi");
+
+    Ok(())
+}
+```
+
 ## What is working
 
 * Authentication

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Pure Rust async implementation of the [Source RCON protocol](https://developer.v
 
 ## To do
 
-* Timeouts
 * Strongly typed commands instead of arbitrary strings
 * Stream UDP logs with password support
 * Implement RCON server for testing purposes and Fun

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,7 @@ use tokio::time::timeout;
 pub struct Client {
     next_packet_id: i32,
     stream: TcpStream,
+    timeout: Duration,
 }
 
 /// Container struct for a response that can be glued together from multiple [Packet]s.
@@ -65,12 +66,13 @@ impl ClientBuilder {
 
         trace!("opened tcp stream to {}, attempting auth", host);
 
-        Client::auth(password, &stream).await?;
+        timeout(self.timeout, Client::auth(password, &stream)).await??;
 
         trace!("auth complete");
 
         Ok(Client {
             next_packet_id: 100, // IDs 1-99 are reserved for auth (even though we realistically only need two)
+            timeout: self.timeout,
             stream,
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use tokio::time::error::Elapsed;
 
 /// Possible errors for the package.
 #[derive(Error, Debug)]
@@ -27,4 +28,7 @@ pub enum RconError {
     /// Returned if you can't remember the password.
     #[error("bad password")]
     AuthenticationError,
+    /// Returned if the server did not respond in time.
+    #[error("timeout")]
+    TimeoutError(#[from] Elapsed),
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -5,7 +5,7 @@ use crate::error::RconError;
 /// PacketType enumerates the possible rcon packet types. They are seen as an
 /// implementation detail of the library and while you can craft your own
 /// packets, hopefully you will not have to.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PacketType {
     /// Referred to as `SERVERDATA_AUTH` in Valve docs. This must be sent to the
     /// server prior to Exec commands.


### PR DESCRIPTION
Adds configurable timeout support in `client::Client` with default of 10 seconds.

Additionally simplifies the auth code somewhat.